### PR TITLE
Change domain-search to quote each domain

### DIFF
--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -58,7 +58,7 @@ subnet <%= @network %> netmask <%= @mask %> {
   option domain-name-servers <%= @nameservers %>;
 <% end -%>
 <% if @search_domains and @search_domains.is_a? Array -%>
-  option domain-search "<%= @search_domains.sort.join(', ') %>";
+  option domain-search "<%= @search_domains.sort.join('", "') %>";
 <% elsif @search_domains -%>
   option domain-search "<%= @search_domains %>";
 <% end -%>


### PR DESCRIPTION
The original set:
  domain-seach "domain1.com, domain2.com"
but should have been
  domain-seach "domain1.com", "domain2.com"
